### PR TITLE
Fix Linux and Windows build

### DIFF
--- a/VAS.Core/VAS.Core.dll.config
+++ b/VAS.Core/VAS.Core.dll.config
@@ -1,5 +1,5 @@
 <configuration>
 	<dllmap dll="libglib-2.0-0.dll" target="libglib-2.0.0.dylib" />
-	<dllmap os="linux" dll="libglib-2.0.dll" target="libglib-2.0.so.0" />
-	<dllmap os="windows" dll="libglib-2.0.dll" target="libglib-2.0-0.dll" />
+	<dllmap os="linux" dll="libglib-2.0-0.dll" target="libglib-2.0.so.0" />
+	<dllmap os="windows" dll="libglib-2.0-0.dll" target="libglib-2.0-0.dll" />
 </configuration>


### PR DESCRIPTION
VAS.core.dll.config was only correct for OSX.