### PR TITLE
Force frame dimensions to the display width and height

### DIFF
--- a/VAS.Core/Store/MediaFile.cs
+++ b/VAS.Core/Store/MediaFile.cs
@@ -109,6 +109,26 @@ namespace VAS.Core.Store
 			set;
 		}
 
+		/// <summary>
+		/// Gets the display width of the video (with PAR correctiion).
+		/// </summary>
+		/// <value>The display width of the video.</value>
+		public uint DisplayVideoWidth {
+			get {
+				return (uint) (VideoWidth * Par);
+			}
+		}
+
+		/// <summary>
+		/// Gets the display height of the video (with PAR correction).
+		/// </summary>
+		/// <value>The display height of the video.</value>
+		public uint DisplayVideoHeight {
+			get {
+				return VideoHeight;
+			}
+		}
+
 		public ushort Fps {
 			get;
 			set;

--- a/VAS.Services/CoreEventsManager.cs
+++ b/VAS.Services/CoreEventsManager.cs
@@ -159,13 +159,16 @@ namespace VAS.Services
 				if (e.CamConfig.Index > 0) {
 					IFramesCapturer auxFramesCapturer;
 					auxFramesCapturer = App.Current.MultimediaToolkit.GetFramesCapturer ();
-					auxFramesCapturer.Open (openedProject.FileSet [e.CamConfig.Index].FilePath);
+					MediaFile file = openedProject.FileSet [e.CamConfig.Index];
+					auxFramesCapturer.Open (file.FilePath);
 					Time offset = openedProject.FileSet [e.CamConfig.Index].Offset;
-					pixbuf = auxFramesCapturer.GetFrame (pos + offset, true, -1, -1);
+					pixbuf = auxFramesCapturer.GetFrame (pos + offset, true,
+					                                     (int) file.DisplayVideoWidth, (int) file.DisplayVideoHeight);
 					auxFramesCapturer.Dispose ();
 				} else {
-					Time offset = openedProject.FileSet.First ().Offset;
-					pixbuf = framesCapturer.GetFrame (pos + offset, true, -1, -1);
+					MediaFile file = openedProject.FileSet.First ();
+					pixbuf = framesCapturer.GetFrame (pos + file.Offset, true,
+					                                  (int) file.DisplayVideoWidth, (int) file.DisplayVideoHeight);
 				}
 			} else {
 				pixbuf = player.CurrentFrame;

--- a/VAS.Tests/Core/Store/TestMediaFile.cs
+++ b/VAS.Tests/Core/Store/TestMediaFile.cs
@@ -78,6 +78,14 @@ namespace VAS.Tests.Core.Store
 			mf.FilePath = Constants.FAKE_PROJECT;
 			Assert.IsTrue (mf.IsFakeCapture);
 		}
+
+		[Test ()]
+		public void TestDisplayDimensions ()
+		{
+			MediaFile mf = new MediaFile {VideoWidth = 640, VideoHeight = 480, Par = 1.333};
+			Assert.AreEqual (480, mf.DisplayVideoHeight);
+			Assert.AreEqual (853, mf.DisplayVideoWidth);
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes a bug in which some frames capturer correct
width and height in videos with PAR != 1 by fixing the width
instead of fixing the height. So the frame used in drawings
has different dimensions when taken from the player or from
the frames capturer.