### PR TITLE
Implement MoveToHome through MoveTo

### DIFF
--- a/VAS.Core/Common/StateController.cs
+++ b/VAS.Core/Common/StateController.cs
@@ -199,16 +199,7 @@ namespace VAS.Core
 			}
 
 			try {
-				if (!await EmptyStateStack ()) {
-					return false;
-				}
-				if (!await home.ScreenState.PreTransition (null)) {
-					return false;
-				}
-				if (!await App.Current.Navigation.Push (home.ScreenState.Panel)) {
-					return false;
-				}
-				App.Current.EventsBroker.Publish (new NavigationEvent { Name = home.Name });
+				await MoveTo (home.Name, null, true);
 				return true;
 			} catch (Exception ex) {
 				Log.Exception (ex);

--- a/VAS.UI.Gtk2/UI/Common/TreeViewBase.cs
+++ b/VAS.UI.Gtk2/UI/Common/TreeViewBase.cs
@@ -210,7 +210,7 @@ namespace VAS.UI.Common
 
 		void PropertyChangedItem (object sender, PropertyChangedEventArgs e)
 		{
-			if (!(sender is IViewModel)) {
+			if (!(sender is IViewModel) || Model == null) {
 				return;
 			}
 			TreeIter iter = dictionaryStore [(IViewModel)sender];


### PR DESCRIPTION
It wasn't calling the PostTransition method, for example.

Also add a check on PropertyChanged, when destroying the treeview it was being called