### PR TITLE
Rename every reference to libcesarplayer

### DIFF
--- a/VAS.Multimedia/Capturer/GstCameraCapturer.cs
+++ b/VAS.Multimedia/Capturer/GstCameraCapturer.cs
@@ -40,10 +40,10 @@ namespace VAS.Multimedia.Capturer
 
 		private LiveSourceTimer timer;
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern unsafe IntPtr gst_camera_capturer_new (out IntPtr err);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern unsafe IntPtr gst_camera_capturer_configure (
 			IntPtr raw, IntPtr output_file, int type, IntPtr source_element,
 			IntPtr device_id, int width, int height, int fps_n, int fps_d,
@@ -52,37 +52,37 @@ namespace VAS.Multimedia.Capturer
 			uint output_width, uint output_height, IntPtr window_handle,
 			out IntPtr err);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_camera_capturer_stop (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_camera_capturer_toggle_pause (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_camera_capturer_start (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_camera_capturer_run (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_camera_capturer_close (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_camera_capturer_expose (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr gst_camera_capturer_get_type ();
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr gst_camera_capturer_enum_audio_devices ();
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr gst_camera_capturer_enum_video_devices (string devname);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr gst_camera_capturer_get_current_frame (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr gst_camera_capturer_unref_pixbuf (IntPtr raw);
 
 		public unsafe GstCameraCapturer (string filename) : base (IntPtr.Zero)

--- a/VAS.Multimedia/Editor/GstVideoSplitter.cs
+++ b/VAS.Multimedia/Editor/GstVideoSplitter.cs
@@ -30,7 +30,7 @@ namespace VAS.Multimedia.Editor
 	public class GstVideoSplitter : GLib.Object, IVideoEditor
 	{
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern unsafe IntPtr gst_video_editor_new (out IntPtr err);
 
 		public event VASCore.ProgressHandler Progress;
@@ -160,7 +160,7 @@ namespace VAS.Multimedia.Editor
 
 		#region Public Methods
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr gst_video_editor_get_type ();
 
 		public static new GLib.GType GType {
@@ -171,7 +171,7 @@ namespace VAS.Multimedia.Editor
 			}
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_video_editor_clear_segments_list (IntPtr raw);
 
 		public void ClearList ()
@@ -179,7 +179,7 @@ namespace VAS.Multimedia.Editor
 			gst_video_editor_clear_segments_list (Handle);
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_video_editor_add_segment (IntPtr raw, string file_path, long start, long duration, double rate, IntPtr title, bool hasAudio,
 		                                                 uint roi_x, uint roi_y, uint roi_w, uint roi_h);
 
@@ -188,7 +188,7 @@ namespace VAS.Multimedia.Editor
 			gst_video_editor_add_segment (Handle, filePath, start, duration, rate, GLib.Marshaller.StringToPtrGStrdup (title), true, (uint)roi.Start.X, (uint)roi.Start.Y, (uint)roi.Width, (uint)roi.Height);
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_video_editor_add_image_segment (IntPtr raw, string file_path, long start, long duration, IntPtr title,
 		                                                       uint roi_x, uint roi_y, uint roi_w, uint roi_h);
 
@@ -197,7 +197,7 @@ namespace VAS.Multimedia.Editor
 			gst_video_editor_add_image_segment (Handle, filePath, start, duration, GLib.Marshaller.StringToPtrGStrdup (title), (uint)roi.Start.X, (uint)roi.Start.Y, (uint)roi.Width, (uint)roi.Height);
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_video_editor_start (IntPtr raw);
 
 		public void Start ()
@@ -205,7 +205,7 @@ namespace VAS.Multimedia.Editor
 			gst_video_editor_start (Handle);
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_video_editor_cancel (IntPtr raw);
 
 		public void Cancel ()
@@ -217,7 +217,7 @@ namespace VAS.Multimedia.Editor
 			}
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_video_editor_init_backend (out int argc, IntPtr argv);
 
 		public static int InitBackend (string argv)
@@ -227,7 +227,7 @@ namespace VAS.Multimedia.Editor
 			return argc;
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool gst_video_editor_set_encoding_format (IntPtr raw,
 		                                                         string output_file,
 		                                                         VideoEncoderType video_codec,

--- a/VAS.Multimedia/Player/GstPlayer.cs
+++ b/VAS.Multimedia/Player/GstPlayer.cs
@@ -38,70 +38,70 @@ namespace VAS.Multimedia.Player
 		MediaFile file;
 		double rate;
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr lgm_video_player_get_type ();
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern unsafe IntPtr lgm_video_player_new (int use_type, out IntPtr error);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern unsafe IntPtr lgm_video_player_set_window_handle (IntPtr raw, IntPtr window_handle);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_open (IntPtr raw, IntPtr uri, out IntPtr error);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_play (IntPtr raw, bool synchronous);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_is_playing (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_video_player_pause (IntPtr raw, bool synchronous);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_video_player_stop (IntPtr raw, bool synchronous);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_video_player_close (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_seek (IntPtr raw, double position);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_seek_time (IntPtr raw, long time, bool accurate, bool synchronous);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_seek_to_next_frame (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_seek_to_previous_frame (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern double lgm_video_player_get_position (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern long lgm_video_player_get_current_time (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern long lgm_video_player_get_stream_length (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern bool lgm_video_player_set_rate (IntPtr raw, double rate);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_video_player_set_volume (IntPtr raw, double volume);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern double lgm_video_player_get_volume (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr lgm_video_player_get_current_frame (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_video_player_unref_pixbuf (IntPtr pixbuf);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_video_player_expose (IntPtr pixbuf);
 
 		public unsafe GstPlayer () : base (IntPtr.Zero)

--- a/VAS.Multimedia/Remuxer/GstRemuxer.cs
+++ b/VAS.Multimedia/Remuxer/GstRemuxer.cs
@@ -31,7 +31,7 @@ namespace VAS.Multimedia.Remuxer
 		public event VASHandlers.ProgressHandler Progress;
 		public event VASHandlers.ErrorHandler Error;
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern unsafe IntPtr gst_remuxer_new (IntPtr input_file, IntPtr output_file, VideoMuxerType muxer, out IntPtr err);
 
 		public unsafe GstRemuxer (string inputFile, string outputFile, VideoMuxerType muxer) : base (IntPtr.Zero)
@@ -183,7 +183,7 @@ namespace VAS.Multimedia.Remuxer
 
 		#endregion
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_remuxer_cancel (IntPtr raw);
 
 		public void Cancel ()
@@ -191,7 +191,7 @@ namespace VAS.Multimedia.Remuxer
 			gst_remuxer_cancel (Handle);
 		}
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void gst_remuxer_start (IntPtr raw);
 
 		public void Start ()

--- a/VAS.Multimedia/Utils/Devices.cs
+++ b/VAS.Multimedia/Utils/Devices.cs
@@ -26,19 +26,19 @@ namespace VAS.Multimedia.Utils
 {
 	public class Devices
 	{
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr lgm_device_enum_video_devices (string source);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr lgm_device_get_formats (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr lgm_device_get_device_name (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_device_free (IntPtr raw);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr lgm_device_video_format_get_info (IntPtr raw, out int width, out int height,
 		                                                       out int fps_n, out int fps_d);
 

--- a/VAS.Multimedia/Utils/GstDiscoverer.cs
+++ b/VAS.Multimedia/Utils/GstDiscoverer.cs
@@ -29,7 +29,7 @@ namespace VAS.Multimedia.Utils
 		const int THUMBNAIL_MAX_HEIGHT = 72;
 		const int THUMBNAIL_MAX_WIDTH = 96;
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern unsafe uint lgm_discover_uri (string uri, out long duration,
 		                                            out uint width, out uint height,
 		                                            out uint fps_n, out uint fps_d,

--- a/VAS.Multimedia/Utils/WindowHandle.cs
+++ b/VAS.Multimedia/Utils/WindowHandle.cs
@@ -22,7 +22,7 @@ namespace VAS.Multimedia.Utils
 {
 	public static class WindowHandle
 	{
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern IntPtr lgm_get_window_handle (IntPtr window);
 
 		public static IntPtr GetWindowHandle (this Gdk.Window window)

--- a/VAS.Multimedia/VAS.Multimedia.dll.config
+++ b/VAS.Multimedia/VAS.Multimedia.dll.config
@@ -1,7 +1,7 @@
 <configuration>
-        <dllmap dll="libcesarplayer.dll" target="libcesarplayer.0.dylib"/>
-        <dllmap os="linux" dll="libcesarplayer.dll" target="libcesarplayer.so.0"/>
-        <dllmap os="windows" dll="libcesarplayer.dll" target="libcesarplayer-0.dll"/>
+        <dllmap dll="libvas.dll" target="libvas.0.dylib"/>
+        <dllmap os="linux" dll="libvas.dll" target="libvas.so.0"/>
+        <dllmap os="windows" dll="libvas.dll" target="libvas-0.dll"/>
         <dllmap dll="libgstreamer-0.10.dll" target="libgstreamer-0.10.0.dylib"/>
         <dllmap os="linux" dll="libgstreamer-0.10.dll" target="libgstreamer-0.10.so.0"/>
         <dllmap os="windows" dll="libgstreamer-0.10.dll" target="libgstreamer-0.10-0.dll"/>

--- a/VAS.UI.Helpers.Gtk2/GtkGlue.cs
+++ b/VAS.UI.Helpers.Gtk2/GtkGlue.cs
@@ -31,7 +31,7 @@ namespace VAS
 		[DllImport ("libgtk-2.0.dll") /* willfully unmapped */]
 		static extern IntPtr gtk_message_dialog_get_message_area (IntPtr dialog);
 
-		[DllImport ("libcesarplayer.dll")]
+		[DllImport ("libvas.dll")]
 		static extern void lgm_gtk_glue_gdk_event_button_set_button (IntPtr evt, uint button);
 
 		[DllImport ("libpango-1.0.dll")]

--- a/VAS.UI.Helpers.Gtk2/VAS.UI.Helpers.Gtk2.dll.config
+++ b/VAS.UI.Helpers.Gtk2/VAS.UI.Helpers.Gtk2.dll.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-	<dllmap dll="libcesarplayer.dll" target="libcesarplayer.0.dylib" />
-	<dllmap os="linux" dll="libcesarplayer.dll" target="libcesarplayer.so.0" />
-	<dllmap os="windows" dll="libcesarplayer.dll" target="libcesarplayer-0.dll" />
+        <dllmap dll="libvas.dll" target="libvas.0.dylib"/>
+        <dllmap os="linux" dll="libvas.dll" target="libvas.so.0"/>
+        <dllmap os="windows" dll="libvas.dll" target="libvas-0.dll"/>
 	<dllmap dll="libgtk-2.0.dll" target="libgtk-quartz-2.0.0.dylib" />
 	<dllmap os="linux" dll="libgtk-2.0.dll" target="libgtk-x11-2.0.so.0" />
 	<dllmap os="windows" dll="libgtk-2.0.dll" target="libgtk-win32-2.0-0.dll" />

--- a/configure.ac
+++ b/configure.ac
@@ -97,9 +97,9 @@ AC_PATH_PROG(COV_HTML, cov-html, no)
 AM_CONDITIONAL(HAVE_COVEM, test x$COVEM != xno)
 
 dnl package checks for libcesarplayer
-PKG_CHECK_MODULES(CESARPLAYER, [gtk+-2.0 >= 2.8 gdk-2.0 gio-2.0 glib-2.0 gstreamer-0.10 gstreamer-audio-0.10 gstreamer-video-0.10 gstreamer-pbutils-0.10 gobject-2.0 gstreamer-interfaces-0.10 gstreamer-tag-0.10 gstreamer-app-0.10])
-AC_SUBST(CESARPLAYER_CFLAGS)
-AC_SUBST(CESARPLAYER_LIBS)
+PKG_CHECK_MODULES(LIBVAS, [gtk+-2.0 >= 2.8 gdk-2.0 gio-2.0 glib-2.0 gstreamer-0.10 gstreamer-audio-0.10 gstreamer-video-0.10 gstreamer-pbutils-0.10 gobject-2.0 gstreamer-interfaces-0.10 gstreamer-tag-0.10 gstreamer-app-0.10])
+AC_SUBST(LIBVAS_CFLAGS)
+AC_SUBST(LIBVAS_LIBS)
 
 AC_MSG_CHECKING([for the OS type])
 ostype=""

--- a/libvas/Makefile.am
+++ b/libvas/Makefile.am
@@ -4,7 +4,7 @@
 AM_CPPFLAGS = \
 	-DPACKAGE_SRC_DIR=\""$(srcdir)"\" \
 	-DPACKAGE_DATA_DIR=\""$(datadir)"\" \
-	$(CESARPLAYER_CFLAGS)
+	$(LIBVAS_CFLAGS)
 
 if OSTYPE_OS_X
 AM_CPPFLAGS += \
@@ -53,7 +53,7 @@ libvas_la_SOURCES = \
 	lgm-utils.h
 
 libvas_la_LDFLAGS = \
-	$(CESARPLAYER_LIBS)
+	$(LIBVAS_LIBS)
 
 if OSTYPE_WINDOWS
 libvas_la_LDFLAGS += -no-undefined
@@ -69,14 +69,14 @@ if WITH_MULTIMEDIA_TOOLS
 noinst_PROGRAMS = test-capturer test-discoverer test-remuxer test-editor
 
 test_capturer_SOURCES = test-capturer.c
-test_capturer_LDADD =  libvas.la $(CESARPLAYER_LIBS)
+test_capturer_LDADD =  libvas.la $(LIBVAS_LIBS)
 
 test_discoverer_SOURCES = test-discoverer.c
-test_discoverer_LDADD =  libvas.la $(CESARPLAYER_LIBS)
+test_discoverer_LDADD =  libvas.la $(LIBVAS_LIBS)
 
 test_remuxer_SOURCES = test-remuxer.c
-test_remuxer_LDADD =  libvas.la $(CESARPLAYER_LIBS)
+test_remuxer_LDADD =  libvas.la $(LIBVAS_LIBS)
 
 test_editor_SOURCES = test-editor.c
-test_editor_LDADD =  libvas.la $(CESARPLAYER_LIBS)
+test_editor_LDADD =  libvas.la $(LIBVAS_LIBS)
 endif

--- a/libvas/Makefile.am
+++ b/libvas/Makefile.am
@@ -29,9 +29,9 @@ baconvideowidget-marshal.c: baconvideowidget-marshal.h
 
 
 lib_LTLIBRARIES = \
-	libcesarplayer.la
+	libvas.la
 
-libcesarplayer_la_SOURCES = \
+libvas_la_SOURCES = \
 	$(BVWMARSHALFILES) \
 	lgm-gtk-glue.c\
 	lgm-gtk-glue.h\
@@ -52,11 +52,11 @@ libcesarplayer_la_SOURCES = \
 	lgm-utils.m\
 	lgm-utils.h
 
-libcesarplayer_la_LDFLAGS = \
+libvas_la_LDFLAGS = \
 	$(CESARPLAYER_LIBS)
 
 if OSTYPE_WINDOWS
-libcesarplayer_la_LDFLAGS += -no-undefined
+libvas_la_LDFLAGS += -no-undefined
 endif
 	
 CLEANFILES = $(BUILT_SOURCES)
@@ -69,14 +69,14 @@ if WITH_MULTIMEDIA_TOOLS
 noinst_PROGRAMS = test-capturer test-discoverer test-remuxer test-editor
 
 test_capturer_SOURCES = test-capturer.c
-test_capturer_LDADD =  libcesarplayer.la $(CESARPLAYER_LIBS)
+test_capturer_LDADD =  libvas.la $(CESARPLAYER_LIBS)
 
 test_discoverer_SOURCES = test-discoverer.c
-test_discoverer_LDADD =  libcesarplayer.la $(CESARPLAYER_LIBS)
+test_discoverer_LDADD =  libvas.la $(CESARPLAYER_LIBS)
 
 test_remuxer_SOURCES = test-remuxer.c
-test_remuxer_LDADD =  libcesarplayer.la $(CESARPLAYER_LIBS)
+test_remuxer_LDADD =  libvas.la $(CESARPLAYER_LIBS)
 
 test_editor_SOURCES = test-editor.c
-test_editor_LDADD =  libcesarplayer.la $(CESARPLAYER_LIBS)
+test_editor_LDADD =  libvas.la $(CESARPLAYER_LIBS)
 endif

--- a/libvas/libvas.cproj
+++ b/libvas/libvas.cproj
@@ -32,7 +32,7 @@
     <SourceDirectory>.</SourceDirectory>
     <DefineSymbols>DEBUG MONODEVELOP OSTYPE_LINUX</DefineSymbols>
     <CompileTarget>SharedLibrary</CompileTarget>
-    <OutputName>libvas</OutputName>
+    <OutputName>libvas.dll</OutputName>
     <CodeGeneration>
       <CodeGeneration ctype="CCompilationParameters" />
     </CodeGeneration>
@@ -47,7 +47,7 @@
     <OutputPath>..\bin</OutputPath>
     <WarningLevel>None</WarningLevel>
     <CompileTarget>SharedLibrary</CompileTarget>
-    <OutputName>libcesarplayer.dll</OutputName>
+    <OutputName>libvas.dll</OutputName>
     <OptimizationLevel>3</OptimizationLevel>
     <DefineSymbols>MONODEVELOP OSTYPE_LINUX</DefineSymbols>
     <SourceDirectory>.</SourceDirectory>


### PR DESCRIPTION
It has been removed from the Makefile.am, the .csproj
and every .cs file that references to it, along with
the correct .dll.config configurations