### PR TITLE
Find the packages on the correct path

### DIFF
--- a/.nuget/nuget.config
+++ b/.nuget/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <config>
+        <add key="repositoryPath" value="../packages" />
+    </config>
+</configuration>


### PR DESCRIPTION
The path is case sensitive on linux and thus we need to
specify the correct path