### PR TITLE
Now PreTransitions calls new Method Initialize

### DIFF
--- a/VAS.Services/State/ScreenState.cs
+++ b/VAS.Services/State/ScreenState.cs
@@ -109,6 +109,11 @@ namespace VAS.Services.State
 
 		public virtual Task<bool> PreTransition (dynamic data)
 		{
+			return Initialize (data);
+		}
+
+		protected Task<bool> Initialize (dynamic data)
+		{
 			CreateViewModel (data);
 			Panel.SetViewModel (ViewModel);
 			foreach (IController controller in Controllers) {


### PR DESCRIPTION
This is done to prevent casting problems with overriden PreTransition
when calling the base method, now if some state overrides PreTransition
It should call Initiaze instead of base.PreTransition()