### PR TITLE
Prevent that loaded template can be null

### DIFF
--- a/VAS.Core/MVVMC/CollectionViewModel.cs
+++ b/VAS.Core/MVVMC/CollectionViewModel.cs
@@ -51,15 +51,19 @@ namespace VAS.Core.MVVMC
 				if (ViewModels != null) {
 					ViewModels.CollectionChanged -= HandleViewModelsCollectionChanged;
 				}
-				if (Model != null) {
-					Model.CollectionChanged -= HandleModelsCollectionChanged;
+				if (model != null) {
+					model.CollectionChanged -= HandleModelsCollectionChanged;
 				}
 				ViewModels.Clear ();
 				modelToViewModel = new Dictionary<TModel, TViewModel> ();
 				model = value;
 				AddViewModels (0, model);
-				ViewModels.CollectionChanged += HandleViewModelsCollectionChanged;
-				model.CollectionChanged += HandleModelsCollectionChanged;
+				if (ViewModels != null) {
+					ViewModels.CollectionChanged += HandleViewModelsCollectionChanged;
+				}
+				if (model != null) {
+					model.CollectionChanged += HandleModelsCollectionChanged;
+				}
 			}
 			get {
 				return model;
@@ -85,11 +89,15 @@ namespace VAS.Core.MVVMC
 
 		void AddViewModels (int index, IEnumerable<TModel> models)
 		{
+			if (models == null) {
+				return;
+			}
+
 			var viewModels = new List<TViewModel> ();
-			foreach (TModel model in models) {
-				var viewModel = CreateInstance (model);
+			foreach (TModel tModel in models) {
+				var viewModel = CreateInstance (tModel);
 				viewModels.Add (viewModel);
-				modelToViewModel [model] = viewModel;
+				modelToViewModel [tModel] = viewModel;
 			}
 			ViewModels.InsertRange (index, viewModels);
 		}

--- a/VAS.Core/ViewModel/TemplateViewModel.cs
+++ b/VAS.Core/ViewModel/TemplateViewModel.cs
@@ -91,7 +91,7 @@ namespace VAS.Core.ViewModel
 			}
 			set {
 				base.Model = value;
-				SubViewModel.Model = Model.List;
+				SubViewModel.Model = Model?.List;
 			}
 		}
 

--- a/VAS.Tests/Services/TestTemplatesController.cs
+++ b/VAS.Tests/Services/TestTemplatesController.cs
@@ -1,0 +1,77 @@
+﻿//
+//  Copyright (C) 2017 Fluendo S.A.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+using System;
+using NUnit.Framework;
+
+namespace VAS.Tests.Services
+{
+	[TestFixture ()]
+	public class TestTemplatesController
+	{
+		DummyTemplatesController templatesController;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			templatesController = new DummyTemplatesController ();
+		}
+
+		[Test ()]
+		public void TestHandleSelectionChanged_LoadedTemplateWithTeamAndPlayer ()
+		{
+			// Arrange
+			Utils.PlayerDummy player = new Utils.PlayerDummy ();
+			DummyTeam team = new DummyTeam ();
+			team.List.Add (player);
+			DummyTeamVM teamVM = new DummyTeamVM () { Model = team };
+
+			templatesController.ViewModel.ViewModels.Add (teamVM);
+
+			// Action
+			templatesController.ViewModel.SelectionReplace (templatesController.ViewModel.ViewModels);
+
+			// Assert
+			Assert.IsNotNull (templatesController.ViewModel.LoadedTemplate,
+						   "Loaded template model");
+			Assert.IsNotEmpty (templatesController.ViewModel.LoadedTemplate.SubViewModel,
+						   "Loaded template subVM");
+		}
+
+		[Test ()]
+		public void TestHandleSelectionChanged_ClearSelectionWithTeamAndPlayer ()
+		{
+			// Arrange
+			Utils.PlayerDummy player = new Utils.PlayerDummy ();
+			DummyTeam team = new DummyTeam ();
+			team.List.Add (player);
+			DummyTeamVM teamVM = new DummyTeamVM () { Model = team };
+
+			templatesController.ViewModel.ViewModels.Add (teamVM);
+			templatesController.ViewModel.SelectionReplace (templatesController.ViewModel.ViewModels);
+
+			// Action
+			templatesController.ViewModel.Selection.Clear ();
+
+			// Assert
+			Assert.IsNull (templatesController.ViewModel.LoadedTemplate.Model,
+						   "Loaded template model");
+			Assert.IsEmpty (templatesController.ViewModel.LoadedTemplate.SubViewModel,
+						   "Loaded template subVM");
+		}
+	}
+}

--- a/VAS.Tests/Utils.cs
+++ b/VAS.Tests/Utils.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -33,6 +34,8 @@ using VAS.Core.Store;
 using VAS.Core.Store.Templates;
 using VAS.Core.ViewModel;
 using VAS.Services;
+using VAS.Services.Controller;
+using VAS.Services.ViewModel;
 
 namespace VAS.Tests
 {
@@ -123,6 +126,18 @@ namespace VAS.Tests
 		}
 	}
 
+	public class DummyTemplatesController : TemplatesController<DummyTeam, DummyTeamVM, Utils.PlayerDummy, DummyPlayerVM>
+	{
+		public DummyTemplatesController ()
+		{
+			ViewModel = new TemplatesManagerViewModel<DummyTeam, DummyTeamVM, Utils.PlayerDummy, DummyPlayerVM> ();
+		}
+
+		protected override bool SaveValidations (DummyTeam model)
+		{
+			throw new NotImplementedException ();
+		}
+	}
 
 	public static class Utils
 	{

--- a/VAS.Tests/VAS.Tests.csproj
+++ b/VAS.Tests/VAS.Tests.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Core\Common\TestRangeObservableCollection.cs" />
     <Compile Include="Core\ViewModel\TestPlayerViewModel.cs" />
     <Compile Include="Services\TestUserStatisticsService.cs" />
+    <Compile Include="Services\TestTemplatesController.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\packages\SQLitePCL.native.sqlite3.v110_xp.0.9.1\build\SQLitePCL.native.sqlite3.v110_xp.targets" Condition="Exists('$(SolutionDir)\packages\SQLitePCL.native.sqlite3.v110_xp.0.9.1\build\SQLitePCL.native.sqlite3.v110_xp.targets')" />


### PR DESCRIPTION
When returning from a canceled modal,loadedTemplate can be null.