### PR TITLE
Live and fake projects error when capturer not started and click button

### DIFF
--- a/VAS.Core/ViewModel/DashboardVM.cs
+++ b/VAS.Core/ViewModel/DashboardVM.cs
@@ -78,6 +78,7 @@ namespace VAS.Core.ViewModel
 			ChangeFitMode = new Command<FitMode> ((p) => FitMode = p);
 
 			ViewModels.CollectionChanged += HandleCollectionChanged;
+			CurrentTime = new Time ();
 		}
 
 		/// <summary>

--- a/VAS.Services/Controller/CoreEventsController.cs
+++ b/VAS.Services/Controller/CoreEventsController.cs
@@ -83,8 +83,10 @@ namespace VAS.Services.Controller
 		{
 			project = (ProjectVM)(viewModel as dynamic);
 			videoPlayer = (VideoPlayerVM)(viewModel as dynamic);
+
+			// FIXME: Remove the try catch when the new interface is passed instead of IViewModel
 			try {
-				capturer = (ICapturerBin)(viewModel as dynamic);
+				capturer = (ICapturerBin)((viewModel as dynamic).Capturer);
 			} catch {
 			}
 

--- a/VAS.Services/Controller/EventsController.cs
+++ b/VAS.Services/Controller/EventsController.cs
@@ -123,9 +123,10 @@ namespace VAS.Services.Controller
 			Timeline = (TimelineVM)(viewModel as dynamic);
 			projectVM = (ProjectVM)(viewModel as dynamic);
 
+			// FIXME: Remove the try catch when the new interface is passed instead of IViewModel
 			try {
-				capturer = (ICapturerBin)(viewModel as dynamic);
-			} catch {
+				capturer = (ICapturerBin)((viewModel as dynamic).Capturer);
+			} catch (Exception e){
 			}
 		}
 

--- a/VAS.Services/Controller/TaggingController.cs
+++ b/VAS.Services/Controller/TaggingController.cs
@@ -66,6 +66,7 @@ namespace VAS.Services.Controller
 			base.Start ();
 			App.Current.EventsBroker.Subscribe<ClickedPCardEvent> (HandleClickedPCardEvent);
 			App.Current.EventsBroker.Subscribe<NewTagEvent> (HandleNewTagEvent);
+			App.Current.EventsBroker.Subscribe<CapturerTickEvent> (HandleCapturerTick);
 
 			foreach (DashboardButtonVM button in project.Dashboard.ViewModels) {
 				button.PropertyChanged += HandlePropertyChanged;
@@ -80,6 +81,7 @@ namespace VAS.Services.Controller
 			base.Stop ();
 			App.Current.EventsBroker.Unsubscribe<ClickedPCardEvent> (HandleClickedPCardEvent);
 			App.Current.EventsBroker.Unsubscribe<NewTagEvent> (HandleNewTagEvent);
+			App.Current.EventsBroker.Unsubscribe<CapturerTickEvent> (HandleCapturerTick);
 
 			foreach (DashboardButtonVM button in project.Dashboard.ViewModels) {
 				button.PropertyChanged -= HandlePropertyChanged;
@@ -240,6 +242,11 @@ namespace VAS.Services.Controller
 			tempContext.ExpiredTimeAction = buttonVM.Click ;
 
 			App.Current.KeyContextManager.AddContext (tempContext);
+		}
+
+		void HandleCapturerTick (CapturerTickEvent e)
+		{
+			project.Dashboard.CurrentTime = e.Time;
 		}
 	}
 }

--- a/VAS.Tests/Services/TestTaggingController.cs
+++ b/VAS.Tests/Services/TestTaggingController.cs
@@ -312,6 +312,16 @@ namespace VAS.Tests.Services
 			Assert.AreEqual (time, project.Dashboard.CurrentTime);
 		}
 
+		[Test]
+		public void TestCapturerTimeUpdated ()
+		{
+			Time time = new Time (3000);
+
+			App.Current.EventsBroker.Publish (new CapturerTickEvent { Time = time });
+
+			Assert.AreEqual (time, project.Dashboard.CurrentTime);
+		}
+
 		void HandleNewDashboardEvent (NewDashboardEvent e)
 		{
 			sendedTimelineEvent = e.TimelineEvent;


### PR DESCRIPTION
- AnalysisState should copy the model not the VM since it is disposed
- Currentime is initialised when the dashboardVM is created 
- CapturerTick is checked by the TaggingController to update the CurrentTime of the VM.