### PR TITLE
Center dialogs on parent manually

### DIFF
--- a/VAS.UI.Gtk2/GUIToolkitBase.cs
+++ b/VAS.UI.Gtk2/GUIToolkitBase.cs
@@ -23,14 +23,12 @@ using Gtk;
 using VAS.Core;
 using VAS.Core.Common;
 using VAS.Core.Events;
-using VAS.Core.Filters;
 using VAS.Core.Interfaces;
 using VAS.Core.Interfaces.GUI;
 using VAS.Core.MVVMC;
 using VAS.Core.Store;
 using VAS.Core.Store.Drawables;
 using VAS.Core.Store.Playlists;
-using VAS.Core.ViewModel;
 using VAS.Drawing;
 using VAS.Drawing.CanvasObjects.Blackboard;
 using VAS.UI.Dialog;
@@ -207,9 +205,11 @@ namespace VAS.UI
 
 		protected void ShowModalWindow (IPanel panel, IPanel parent)
 		{
-			if (panel is Gtk.Dialog) {
-				(panel as Gtk.Dialog).TransientFor = ((Bin)parent).Toplevel as Window;
-				(panel as Gtk.Dialog).DeleteEvent += ModalWindowDeleteEvent;
+			var dialog = panel as Gtk.Dialog;
+			if (dialog != null) {
+				dialog.TransientFor = ((Bin)parent).Toplevel as Window;
+				dialog.DeleteEvent += ModalWindowDeleteEvent;
+				dialog.Center ();
 				panel.OnLoad ();
 			} else {
 				ExternalWindow modalWindow = new ExternalWindow ();

--- a/VAS.UI.Helpers.Gtk2/ExtensionMethods.cs
+++ b/VAS.UI.Helpers.Gtk2/ExtensionMethods.cs
@@ -1,0 +1,82 @@
+﻿//
+//  Copyright (C) 2017 Fluendo S.A.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+using System;
+using Gdk;
+using Gtk;
+
+namespace VAS.UI.Helpers
+{
+	/// <summary>
+	/// Provides extension methods for Gtk+
+	/// </summary>
+	public static class ExtensionMethods
+	{
+		/// <summary>
+		/// Centers a dialog on its parent. Dialogs are centered in Show () only if TransientFor is set,
+		/// which has to be done in the constructor with Stetic. When we can't this function can be used instead.
+		/// This implementation is a C# port of the C implementation used in from gtk/gtkwindow.c
+		/// </summary>
+		/// <param name="dialog">Widget to center.</param>
+		public static void Center (this Gtk.Dialog dialog)
+		{
+			int monitorNum;
+			int ox, oy, x, y, w, h;
+			Widget parent;
+
+			parent = dialog.TransientFor;
+
+			if (parent.GdkWindow != null) {
+				monitorNum = Screen.Default.GetMonitorAtWindow (parent.GdkWindow);
+			} else {
+				monitorNum = -1;
+			}
+
+			w = dialog.Allocation.Width;
+			h = dialog.Allocation.Height;
+
+			parent.GdkWindow.GetOrigin (out ox, out oy);
+			x = ox + (parent.Allocation.Width - dialog.Allocation.Width) / 2;
+			y = oy + (parent.Allocation.Height - dialog.Allocation.Height) / 2;
+
+			if (monitorNum >= 0) {
+				var monitor = Screen.Default.GetMonitorGeometry (monitorNum);
+				ClamWindowToRectangle (ref x, ref y, w, h, monitor);
+			}
+
+			dialog.Move (x, y);
+		}
+
+		static void Clamp (ref int @base, int extent, int clampBase, int clampExtent)
+		{
+			if (extent > clampExtent) {
+				/* Center */
+				@base = clampBase + clampExtent / 2 - extent / 2;
+			} else if (@base < clampBase) {
+				@base = clampBase;
+			} else if (@base + extent > clampBase + clampExtent) {
+				@base = clampBase + clampExtent - extent;
+			}
+		}
+
+		static void ClamWindowToRectangle (ref int x, ref int y, int width, int height, Rectangle rect)
+		{
+			Clamp (ref x, width, rect.X, rect.Width);
+			Clamp (ref y, height, rect.Y, rect.Height);
+		}
+	}
+}

--- a/VAS.UI.Helpers.Gtk2/VAS.UI.Helpers.Gtk2.csproj
+++ b/VAS.UI.Helpers.Gtk2/VAS.UI.Helpers.Gtk2.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Bindings\SpinBinding.cs" />
     <Compile Include="Bindings\ColorButtonBinding.cs" />
     <Compile Include="UrlHelper.cs" />
+    <Compile Include="ExtensionMethods.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
When the dialog's contructor has been called and Show ()
is called before setting TransientFor, we need to manually
center it.