### PR TITLE
Also sync all properties when the Model changes

### DIFF
--- a/VAS.Core/MVVMC/ViewModelBase.cs
+++ b/VAS.Core/MVVMC/ViewModelBase.cs
@@ -87,6 +87,8 @@ namespace VAS.Core.MVVMC
 
 	public class ViewModelBase<T> : ViewModelBase, IViewModel<T> where T : class, INotifyPropertyChanged
 	{
+		T model;
+
 		/// <summary>
 		/// Gets or sets the model used by this ViewModel.
 		/// We disable Foody's equality check since we work sometimes with
@@ -96,8 +98,13 @@ namespace VAS.Core.MVVMC
 		/// <value>The model.</value>
 		[PropertyChanged.DoNotCheckEquality]
 		public virtual T Model {
-			set;
-			get;
+			get {
+				return model;
+			}
+			set {
+				model = value;
+				Sync ();
+			}
 		}
 
 		protected override void ForwardPropertyChanged (object sender, PropertyChangedEventArgs e)

--- a/VAS.Core/ViewModel/DashboardButtonVM.cs
+++ b/VAS.Core/ViewModel/DashboardButtonVM.cs
@@ -48,12 +48,12 @@ namespace VAS.Core.ViewModel
 				return base.Model;
 			}
 			set {
-				base.Model = value;
 				ActionLinks.Model = value.ActionLinks;
 				HotKey.Model = value.HotKey;
+				base.Model = value;
 			}
 		}
-		
+
 		/// <summary>
 		/// Gets the DashboardButtonView.
 		/// </summary>

--- a/VAS.Core/ViewModel/KeyConfigVM.cs
+++ b/VAS.Core/ViewModel/KeyConfigVM.cs
@@ -46,8 +46,8 @@ namespace VAS.Core.ViewModel
 				return base.Model;
 			}
 			set {
+				initialHotkey = value.Key.Clone ();
 				base.Model = value;
-				initialHotkey = Model.Key.Clone ();
 			}
 		}
 

--- a/VAS.Tests/MVVMC/TestViewModelBase.cs
+++ b/VAS.Tests/MVVMC/TestViewModelBase.cs
@@ -170,6 +170,20 @@ namespace VAS.Tests.MVVMC
 
 			Assert.IsNull (propertyName);
 		}
+
+		[Test]
+		public void Model_Set_SyncCalled ()
+		{
+			bool called = false;
+			var viewModel = new ViewModelBase<StorableBase> ();
+			viewModel.PropertyChanged += (sender, e) => {
+				called |= e.PropertyName == null;
+			};
+
+			viewModel.Model = new StorableBase ();
+
+			Assert.IsTrue (called);
+		}
 	}
 }
 


### PR DESCRIPTION
When the model is changed in a ViewModel we also want
the View to resync all properties, as if Sync() was called