### PR TITLE
Use Xamarin.Mac from the prefix

### DIFF
--- a/VAS.Services/VAS.Services.Net45.csproj
+++ b/VAS.Services/VAS.Services.Net45.csproj
@@ -43,7 +43,6 @@
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Xamarin.Mac">
-      <HintPath>/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono/4.5/Xamarin.Mac.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="Sparkle">


### PR DESCRIPTION
This should prevent xbuild to copy the custom OS X
assemblies referenced from Xamarin.Mac, like System.Core,
to the bin folder. We prevent this way mixing framework versions
since those could have been compiled against a more recent
framework than the one we use.