### PR TITLE
LON-974: Do a MoveToHome in CanShutdown callback

### DIFF
--- a/VAS.Services/AppUpdater/SparkleWin.cs
+++ b/VAS.Services/AppUpdater/SparkleWin.cs
@@ -87,6 +87,14 @@ namespace VAS.Services.AppUpdater
 			taskResult.ConfigureAwait (false);
 			// Because this is a delegate and we don't have an option to await the result of the task, Wait() it with a
 			// continuation in a different thread to avoid blocking.
+			if (taskResult.Result) {
+				//Move To Home to close any opened projects before HandleShutdownRequestCallback
+				Task<bool> taskHomeResult = App.Current.GUIToolkit.Invoke (() => {
+					return App.Current.StateController.MoveToHome ();
+				});
+				taskHomeResult.ConfigureAwait (false);
+				return taskHomeResult.Result;
+			}
 			return taskResult.Result;
 		}
 


### PR DESCRIPTION
The HandleShutdownRequestCallback should end the application
immediately, so we shouldn't prompt the user to close any project
because it launches the installer even if the user doesn't
close the application.