### PR TITLE
Fix InvalidOperationException when the task is already completed

### DIFF
--- a/VAS.UI.Gtk2/GUIToolkitBase.cs
+++ b/VAS.UI.Gtk2/GUIToolkitBase.cs
@@ -345,7 +345,7 @@ namespace VAS.UI
 		/// <returns><c>true</c>, if task completion result was set, <c>false</c> otherwise.</returns>
 		bool SetTaskCompletionResult ()
 		{
-			tcs.SetResult (taskResult);
+			tcs.TrySetResult (taskResult);
 			return false;
 		}
 	}


### PR DESCRIPTION
The task might have already been moved to the completed state
before the main loop is free to run SetTaskCompletitionResult.