### PR TITLE
Send TrackEvents for ShowUpgradeDialogs and UpgradeLinksClicked

### DIFF
--- a/VAS.Core/Events/Events.cs
+++ b/VAS.Core/Events/Events.cs
@@ -504,4 +504,14 @@ namespace VAS.Core.Events
 	{
 		public TagButtonVM ButtonVM { get; set; }
 	}
+
+	public class LimitationDialogShownEvent
+	{
+		public string LimitationName { get; set; }
+		public string Source { get; set; }
+	}
+
+	public class UpgradeLinkClickedEvent : LimitationDialogShownEvent
+	{
+	}
 }

--- a/VAS.Core/Events/Events.cs
+++ b/VAS.Core/Events/Events.cs
@@ -511,7 +511,9 @@ namespace VAS.Core.Events
 		public string Source { get; set; }
 	}
 
-	public class UpgradeLinkClickedEvent : LimitationDialogShownEvent
+	public class UpgradeLinkClickedEvent
 	{
+		public string LimitationName { get; set; }
+		public string Source { get; set; }
 	}
 }

--- a/VAS.Services/LicenseLimitationsService.cs
+++ b/VAS.Services/LicenseLimitationsService.cs
@@ -190,12 +190,12 @@ namespace VAS.Services
 			if (limitationVM.Enabled) {
 				dynamic properties = new ExpandoObject ();
 				properties.limitationVM = limitationVM;
-				//Task.Run (async () => 
-				//await 
-				return App.Current.StateController.MoveToModal (UpgradeLimitationState.NAME, properties);
-				         //).GetAwaiter ().GetResult ();
 
-				//return AsyncHelpers.Return (true);
+				App.Current.EventsBroker.Publish (new LimitationDialogShownEvent {
+					LimitationName = limitationVM.RegisterName,
+					Source = App.Current.StateController.Current.Name
+				});
+				return App.Current.StateController.MoveToModal (UpgradeLimitationState.NAME, properties);
 			} else {
 				return AsyncHelpers.Return (false);
 			}
@@ -207,6 +207,15 @@ namespace VAS.Services
 			foreach (var limitation in GetAll<CountLimitationVM> ().Select ((arg) => arg.Model)) {
 				limitation.Enabled = enable;
 			}
+		}
+
+		protected void OpenUpgradeLink (string url, string sourcePoint, string limitationName)
+		{
+			Utils.OpenURL (url, sourcePoint);
+			App.Current.EventsBroker.Publish (new UpgradeLinkClickedEvent{
+				LimitationName = limitationName,
+				Source = "LimitationWidget"
+			});
 		}
 
 		protected abstract void UpdateFeatureLimitations ();

--- a/VAS.Tests/Utils.cs
+++ b/VAS.Tests/Utils.cs
@@ -121,10 +121,10 @@ namespace VAS.Tests
 		{
 		}
 
-		public new Dictionary<string, string> UserProperties
+		public new Dictionary<string, string> GeneralProperties
 		{
 			get {
-				return base.UserProperties;
+				return base.GeneralProperties;
 			}
 		}
 	}


### PR DESCRIPTION
- Two new events are created to publish when a upgrade dialog is shown and
  when user clicks an upgrade button
- UserStatisticsService subscribe to those events to be able to send TrackEvents
  to HockeyApp / AppInsights
- Add a GeneralProperties to send those properties to every trackEvent, use MergeProperties
  to merge general properties with custom properties for that event.