### PR TITLE
Improve OneWayPropertyBinding to be less verbose

### DIFF
--- a/VAS.Core/MVVMC/BindingsExtensions.cs
+++ b/VAS.Core/MVVMC/BindingsExtensions.cs
@@ -30,9 +30,11 @@ namespace VAS.Core.MVVMC
 		/// <param name="dest">Destination.</param>
 		/// <param name="sourceExpression">Source expression.</param>
 		/// <param name="targetExpression">Target expression.</param>
-		public static OneWayPropertyBinding<T> Bind<T> (this object dest, Expression<Func<IViewModel, T>> sourceExpression, Expression<Func<object, T>> targetExpression)
+		public static OneWayPropertyBinding<TProperty> Bind<TTarget, TProperty> (this TTarget dest,
+																				 Expression<Func<TTarget, TProperty>> targetExpression,
+																				 Expression<Func<IViewModel, TProperty>> sourceExpression)
 		{
-			return new OneWayPropertyBinding<T> (dest, sourceExpression, targetExpression);
+			return new OneWayPropertyBinding<TProperty, TTarget> (dest, sourceExpression, targetExpression);
 		}
 	}
 }

--- a/VAS.Core/MVVMC/OneWayPropertyBinding.cs
+++ b/VAS.Core/MVVMC/OneWayPropertyBinding.cs
@@ -26,19 +26,20 @@ namespace VAS.Core.MVVMC
 	/// This class provides one way property binding.
 	/// <see cref="IViewModel" /> property is passed to write action callback performed on the class that setted the binding.
 	/// </summary>
-	public class OneWayPropertyBinding<T> : PropertyBinding<T>
+	public class OneWayPropertyBinding<TSourceProperty> : PropertyBinding<TSourceProperty>
 	{
-		Action<T> writeAction;
+		protected Action<TSourceProperty> writeAction;
 
-		public OneWayPropertyBinding (Expression<Func<IViewModel, T>> propertyExpression, Action<T> writeAction) : base (propertyExpression)
+		public OneWayPropertyBinding (Expression<Func<IViewModel, TSourceProperty>> propertyExpression, Action<TSourceProperty> writeAction) : base (propertyExpression)
 		{
 			this.writeAction = writeAction;
 		}
 
-		public OneWayPropertyBinding (object dest, Expression<Func<IViewModel, T>> sourceExpression, Expression<Func<object, T>> targetExpression) : base (sourceExpression)
+		public OneWayPropertyBinding (object dest, Expression<Func<IViewModel, TSourceProperty>> sourceExpression,
+									  Expression<Func<object, TSourceProperty>> targetExpression) : base (sourceExpression)
 		{
-			var setter = CreateSetter<object> (targetExpression, out string memberName);
-			Action<T> setterAction = (T t) => setter.Invoke (dest, t);
+			var setter = CreateSetter (targetExpression, out string memberName);
+			Action<TSourceProperty> setterAction = (TSourceProperty t) => setter.Invoke (dest, t);
 			this.writeAction = setterAction;
 		}
 
@@ -50,9 +51,20 @@ namespace VAS.Core.MVVMC
 		{
 		}
 
-		protected override void WriteViewValue (T val)
+		protected override void WriteViewValue (TSourceProperty val)
 		{
 			this.writeAction (val);
+		}
+	}
+
+	public class OneWayPropertyBinding<TSourceProperty, TTarget> : OneWayPropertyBinding<TSourceProperty>
+	{
+		public OneWayPropertyBinding (TTarget dest, Expression<Func<IViewModel, TSourceProperty>> sourceExpression,
+									  Expression<Func<TTarget, TSourceProperty>> targetExpression) : base (sourceExpression, null)
+		{
+			var setter = CreateSetter (targetExpression, out string memberName);
+			Action<TSourceProperty> setterAction = (TSourceProperty t) => setter.Invoke (dest, t);
+			this.writeAction = setterAction;
 		}
 	}
 }

--- a/VAS.Core/ViewModel/CountLimitationBarChartVM.cs
+++ b/VAS.Core/ViewModel/CountLimitationBarChartVM.cs
@@ -118,8 +118,8 @@ namespace VAS.Core.ViewModel
 		/// </summary>
 		public void Bind ()
 		{
-			ctx.Add (BarChart.LeftSerie.Bind (vm => ((CountLimitationVM)vm).Remaining, vm => ((SeriesVM)vm).Elements));
-			ctx.Add (BarChart.RightSerie.Bind (vm => ((CountLimitationVM)vm).Count, vm => ((SeriesVM)vm).Elements));
+			ctx.Add (BarChart.LeftSerie.Bind (s => s.Elements, vm => ((CountLimitationVM)vm).Remaining));
+			ctx.Add (BarChart.RightSerie.Bind (s => s.Elements, vm => ((CountLimitationVM)vm).Count));
 			ctx.UpdateViewModel (Limitation);
 		}
 
@@ -133,8 +133,7 @@ namespace VAS.Core.ViewModel
 
 		void HandlePropertyChanged (object sender, PropertyChangedEventArgs e)
 		{
-			if(Limitation == null || BarChart == null)
-			{
+			if (Limitation == null || BarChart == null) {
 				return;
 			}
 			if (NeedsSync (e?.PropertyName, nameof (Limitation.Count))) {

--- a/VAS.Tests/MVVMC/TestOneWayPropertyBinding.cs
+++ b/VAS.Tests/MVVMC/TestOneWayPropertyBinding.cs
@@ -79,8 +79,8 @@ namespace VAS.Tests.MVVMC
 			var view = new DummyOneWayPropertyView ();
 			var viewModel = new DummyOneWayPropertyViewModel ();
 			view.BindingContext = new BindingContext ();
-			view.BindingContext.Add (view.Bind (vm => ((DummyOneWayPropertyViewModel)vm).ViewModelProperty,
-															 v => ((DummyOneWayPropertyView)v).ViewProperty));
+			view.BindingContext.Add (view.Bind (v => v.ViewProperty,
+												vm => ((DummyOneWayPropertyViewModel)vm).ViewModelProperty));
 			view.ViewModel = viewModel;
 
 			///Act
@@ -186,8 +186,8 @@ namespace VAS.Tests.MVVMC
 			};
 
 			var binding = new OneWayPropertyBinding<int> (destination,
-														  (vm) => ((ChartVM)vm).RightPadding,
-														  (vm) => ((ChartVM)vm).BottomPadding);
+														  (vm) => ((ChartVM)vm).BottomPadding,
+														  (vm) => ((ChartVM)vm).RightPadding);
 
 			binding.ViewModel = source;
 

--- a/VAS.UI.Gtk2/UI/Dialog/AboutDialog.cs
+++ b/VAS.UI.Gtk2/UI/Dialog/AboutDialog.cs
@@ -95,13 +95,13 @@ namespace VAS.UI.Dialog
 		{
 			bindingContext = this.GetBindingContext ();
 
-			bindingContext.Add (this.Bind (vm => ((AboutVM)vm).ProgramName, v => ((AboutDialog)v).ProgramName));
-			bindingContext.Add (this.Bind (vm => ((AboutVM)vm).Version, v => ((AboutDialog)v).Version));
-			bindingContext.Add (this.Bind (vm => ((AboutVM)vm).Copyright, v => ((AboutDialog)v).Copyright));
-			bindingContext.Add (this.Bind (vm => ((AboutVM)vm).Website, v => ((AboutDialog)v).Website));
-			bindingContext.Add (this.Bind (vm => ((AboutVM)vm).License, v => ((AboutDialog)v).License));
-			bindingContext.Add (this.Bind (vm => ((AboutVM)vm).Authors, v => ((AboutDialog)v).Authors));
-			bindingContext.Add (this.Bind (vm => ((AboutVM)vm).TranslatorCredits, v => ((AboutDialog)v).TranslatorCredits));
+			bindingContext.Add (this.Bind (v => v.ProgramName, vm => ((AboutVM)vm).ProgramName));
+			bindingContext.Add (this.Bind (v => v.Version, vm => ((AboutVM)vm).Version));
+			bindingContext.Add (this.Bind (v => v.Copyright, vm => ((AboutVM)vm).Copyright));
+			bindingContext.Add (this.Bind (v => v.Website, vm => ((AboutVM)vm).Website));
+			bindingContext.Add (this.Bind (v => v.License, vm => ((AboutVM)vm).License));
+			bindingContext.Add (this.Bind (v => v.Authors, vm => ((AboutVM)vm).Authors));
+			bindingContext.Add (this.Bind (v => v.TranslatorCredits, vm => ((AboutVM)vm).TranslatorCredits));
 		}
 
 		void HandleResponse (object o, ResponseArgs args)


### PR DESCRIPTION
Add a new generic to type the target so that we don't have
to use a cast in the expression