### PR TITLE
Improve preformance of filters

### DIFF
--- a/VAS.Tests/Core/Filters/TestPredicates.cs
+++ b/VAS.Tests/Core/Filters/TestPredicates.cs
@@ -435,6 +435,88 @@ namespace VAS.Tests.Core.Filters
 			Assert.IsFalse (container.Active);
 			Assert.IsTrue (container.Filter (""));
 		}
+
+
+		[Test]
+		public void SetActive_1LevelCompositePredicate_ActivePropertyChangedEittedOnce ()
+		{
+			int count = 0;
+
+			// Arrange
+			var filter = new OrPredicate<string> {
+				new Predicate<string> { Expression = (ev) => true },
+				new Predicate<string> { Expression = (ev) => true },
+			};
+			filter.PropertyChanged += (sender, e) => count++;
+
+			filter.Active = false;
+
+			Assert.AreEqual (1, count);
+		}
+
+		[Test]
+		public void SetActive_1LevelCompositePredicateActiveNotChanged_ActivePropertyChangedEittedOnce ()
+		{
+			int count = 0;
+
+			// Arrange
+			var filter = new OrPredicate<string> {
+				new Predicate<string> { Expression = (ev) => true },
+				new Predicate<string> { Expression = (ev) => true },
+			};
+			filter.PropertyChanged += (sender, e) => count++;
+
+			filter.Active = true;
+
+			Assert.AreEqual (0, count);
+		}
+
+		[Test]
+		public void SetActive_2LevelCompositePredicateRootChanged_ActivePropertyChangedEittedOnce ()
+		{
+			int count = 0;
+
+			// Arrange
+			var filter = new OrPredicate<string> {
+				new OrPredicate<string> {
+					new Predicate<string> { Expression = (ev) => true },
+					new Predicate<string> { Expression = (ev) => true },
+				},
+				new OrPredicate<string> {
+					new Predicate<string> { Expression = (ev) => true },
+					new Predicate<string> { Expression = (ev) => true },
+				}
+			};
+			filter.PropertyChanged += (sender, e) => count++;
+
+			filter.Active = false;
+
+			Assert.AreEqual (1, count);
+		}
+
+		[Test]
+		public void SetActive_2LevelCompositePredicateChildChanged_ActivePropertyChangedEittedOnce ()
+		{
+			int count = 0;
+			var childFilter = new Predicate<string> { Expression = (ev) => true };
+
+			// Arrange
+			var filter = new OrPredicate<string> {
+				new OrPredicate<string> {
+					new Predicate<string> { Expression = (ev) => true },
+					childFilter,
+				},
+				new OrPredicate<string> {
+					new Predicate<string> { Expression = (ev) => true },
+					new Predicate<string> { Expression = (ev) => true },
+				}
+			};
+			filter.PropertyChanged += (sender, e) => count++;
+
+			childFilter.Active = false;
+
+			Assert.AreEqual (1, count);
+		}
 	}
 }
 

--- a/VAS.Tests/Services/TestEventsFilterController.cs
+++ b/VAS.Tests/Services/TestEventsFilterController.cs
@@ -115,6 +115,29 @@ namespace VAS.Tests.Services
 		}
 
 		[Test]
+		public void ApplyFilter_EventTypeOne_VisiblePropertyChangedEmmittedOnlyForEventsChangingVisibility ()
+		{
+			int changedCount = 0;
+			var changed = new HashSet<TimelineEventVM> ();
+
+			// Arrange
+			timelineVM.Filters.Active = false;
+			foreach (var evt in timelineVM.FullTimeline.ViewModels) {
+				evt.PropertyChanged += (sender, e) => {
+					changedCount++;
+					changed.Add (evt);
+				};
+			}
+
+			// Act
+			timelineVM.EventTypesPredicate.Elements [0].Active = true;
+
+			// Assert
+			Assert.AreEqual (timelineVM.FullTimeline.Count (e => !e.Visible), changedCount);
+		}
+
+
+		[Test]
 		public void ApplyFilter_AllFiltersActive_AllVisible ()
 		{
 			// Arrange


### PR DESCRIPTION
In composite predicates emit the Active property chagned
event only once