### PR TITLE
Add the option to create a PlaylistElementVM based on a TimelineEventVM

### DIFF
--- a/VAS.Core/Interfaces/IViewModelFactoryService.cs
+++ b/VAS.Core/Interfaces/IViewModelFactoryService.cs
@@ -1,0 +1,37 @@
+﻿//
+//  Copyright (C) 2018 Fluendo S.A.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+using System;
+using VAS.Core.ViewModel;
+using VAS.Core.Store;
+
+namespace VAS.Core.Interfaces
+{
+	/// <summary>
+	/// An interface for creating correctly typed ViewModel instances based on it's model, this is useful to work with
+	/// base classes and create child viewmodels without knowing the reference on it.
+	/// </summary>
+	public interface IViewModelFactoryService : IService
+	{
+		/// <summary>
+		/// Creates a TimelineEventVM based on a TimelineEvent model
+		/// </summary>
+		/// <returns>The TimelineEventVM</returns>
+		/// <param name="timelineEvent">the timeline event model</param>
+		TimelineEventVM CreateTimelineEventVM (TimelineEvent timelineEvent);
+	}
+}

--- a/VAS.Core/Interfaces/IViewModelFactoryService.cs
+++ b/VAS.Core/Interfaces/IViewModelFactoryService.cs
@@ -16,8 +16,11 @@
 //  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
 //
 using System;
-using VAS.Core.ViewModel;
+using System.Collections.Generic;
+using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.MVVMC;
 using VAS.Core.Store;
+using VAS.Core.ViewModel;
 
 namespace VAS.Core.Interfaces
 {
@@ -25,13 +28,21 @@ namespace VAS.Core.Interfaces
 	/// An interface for creating correctly typed ViewModel instances based on it's model, this is useful to work with
 	/// base classes and create child viewmodels without knowing the reference on it.
 	/// </summary>
-	public interface IViewModelFactoryService : IService
+	public interface IViewModelFactoryService
 	{
 		/// <summary>
-		/// Creates a TimelineEventVM based on a TimelineEvent model
+		/// Adds a new TypeMapping
 		/// </summary>
-		/// <returns>The TimelineEventVM</returns>
-		/// <param name="timelineEvent">the timeline event model</param>
-		TimelineEventVM CreateTimelineEventVM (TimelineEvent timelineEvent);
+		/// <param name="modelType">the model type</param>
+		/// <param name="viewModelType">the viewmodel type</param>
+		void AddTypeMapping (Type modelType, Type viewModelType);
+
+		/// <summary>
+		/// Creates a ViewModel based on a Model
+		/// </summary>
+		/// <returns>The derived instance of the ViewModel</returns>
+		/// <param name="model">the model</param>
+		TViewModel CreateViewModel<TViewModel, TModel> (TModel model)
+			where TViewModel : IViewModel<TModel>, new();
 	}
 }

--- a/VAS.Core/VAS.Core.projitems
+++ b/VAS.Core/VAS.Core.projitems
@@ -307,6 +307,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MVVMC\Locator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\NetworkManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Interfaces\INetworkManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Interfaces\IViewModelFactoryService.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Common\" />

--- a/VAS.Core/ViewModel/DashboardButtonCollectionVM.cs
+++ b/VAS.Core/ViewModel/DashboardButtonCollectionVM.cs
@@ -33,9 +33,6 @@ namespace VAS.Core.ViewModel
 		public DashboardButtonCollectionVM ()
 		{
 			cachedButtonVMs = new Dictionary<DashboardButton, DashboardButtonVM> ();
-			TypeMappings.Add (typeof (AnalysisEventButton), typeof (AnalysisEventButtonVM));
-			TypeMappings.Add (typeof (TagButton), typeof (TagButtonVM));
-			TypeMappings.Add (typeof (TimerButton), typeof (TimerButtonVM));
 		}
 
 		protected override DashboardButtonVM CreateInstance (DashboardButton model)

--- a/VAS.Core/ViewModel/PlaylistElementVM.cs
+++ b/VAS.Core/ViewModel/PlaylistElementVM.cs
@@ -73,14 +73,21 @@ namespace VAS.Core.ViewModel
 		/// Gets or sets a value indicating whether this <see cref="T:VAS.Core.ViewModel.PlaylistElementVM"/> is playing.
 		/// </summary>
 		/// <value><c>true</c> if playing; otherwise, <c>false</c>.</value>
-		public bool Playing { get; set; }
+		public virtual bool Playing { get; set; }
 	}
 
 	public class PlaylistPlayElementVM : PlaylistElementVM, IPlayableEvent
 	{
+		IViewModelFactoryService factoryService;
+
 		public PlaylistPlayElementVM ()
 		{
-			Play = new TimelineEventVM ();
+			factoryService = App.Current.DependencyRegistry.Retrieve<IViewModelFactoryService> (InstanceType.Default);
+		}
+
+		public PlaylistPlayElementVM (TimelineEventVM play) : this ()
+		{
+			Play = play;
 		}
 
 		/// <summary>
@@ -100,7 +107,7 @@ namespace VAS.Core.ViewModel
 			}
 			set {
 				base.Model = value;
-				Play.Model = ((PlaylistPlayElement)value)?.Play;
+				SetModelToPlay ((PlaylistPlayElement)value);
 			}
 		}
 
@@ -120,6 +127,20 @@ namespace VAS.Core.ViewModel
 		public TimelineEventVM Play {
 			get;
 			set;
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:VAS.Core.ViewModel.PlaylistPlayElementVM"/> is playing.
+		/// This updates <see cref="T:VAS.Core.ViewModel.TimelineEventVM"/> Playing property also
+		/// </summary>
+		/// <value><c>true</c> if playing; otherwise, <c>false</c>.</value>
+		public override bool Playing {
+			get {
+				return Play.Playing;
+			}
+			set {
+				Play.Playing = value;
+			}
 		}
 
 		/// <summary>
@@ -157,6 +178,17 @@ namespace VAS.Core.ViewModel
 		/// </summary>
 		/// <value>The VAS . core. interfaces. IP laylist event element. cameras config.</value>
 		RangeObservableCollection<CameraConfig> IPlaylistEventElement.CamerasConfig { get => TypedModel.CamerasConfig; set => TypedModel.CamerasConfig = value; }
+
+		void SetModelToPlay (PlaylistPlayElement e)
+		{
+			if (e == null) {
+				return;
+			}
+			if (Play == null) {
+				Play = factoryService.CreateTimelineEventVM (e.Play);
+			}
+			Play.Model = ((PlaylistPlayElement)e)?.Play;
+		}
 	}
 
 	public class PlaylistVideoVM : PlaylistElementVM

--- a/VAS.Core/ViewModel/PlaylistElementVM.cs
+++ b/VAS.Core/ViewModel/PlaylistElementVM.cs
@@ -185,7 +185,7 @@ namespace VAS.Core.ViewModel
 				return;
 			}
 			if (Play == null) {
-				Play = factoryService.CreateTimelineEventVM (e.Play);
+				Play = factoryService.CreateViewModel<TimelineEventVM, TimelineEvent> (e.Play);
 			}
 			Play.Model = ((PlaylistPlayElement)e)?.Play;
 		}

--- a/VAS.Core/ViewModel/PlaylistVM.cs
+++ b/VAS.Core/ViewModel/PlaylistVM.cs
@@ -34,14 +34,6 @@ namespace VAS.Core.ViewModel
 	{
 		int indexSelection = 0;
 
-		public PlaylistVM ()
-		{
-			SubViewModel.TypeMappings.Add (typeof (PlaylistPlayElement), typeof (PlaylistPlayElementVM));
-			SubViewModel.TypeMappings.Add (typeof (PlaylistVideo), typeof (PlaylistVideoVM));
-			SubViewModel.TypeMappings.Add (typeof (PlaylistImage), typeof (PlaylistImageVM));
-			SubViewModel.TypeMappings.Add (typeof (PlaylistDrawing), typeof (PlaylistDrawingVM));
-		}
-
 		/// <summary>
 		/// Gets or sets the name of the playlist.
 		/// </summary>

--- a/VAS.Core/ViewModel/TimelineEventVM.cs
+++ b/VAS.Core/ViewModel/TimelineEventVM.cs
@@ -251,21 +251,5 @@ namespace VAS.Core.ViewModel
 			return ret;
 		}
 	}
-
-	/// <summary>
-	/// Timeline event ViewModel Generic Base class
-	/// </summary>
-	public class TimelineEventVM<T> : TimelineEventVM, IViewModel<T>
-		where T : TimelineEvent
-	{
-		public virtual new T Model {
-			get {
-				return (T)base.Model;
-			}
-			set {
-				base.Model = value;
-			}
-		}
-	}
 }
 

--- a/VAS.Core/ViewModel/TimelineVM.cs
+++ b/VAS.Core/ViewModel/TimelineVM.cs
@@ -91,7 +91,6 @@ namespace VAS.Core.ViewModel
 			if (Model != null) {
 				Model.IgnoreEvents = true;
 			}
-			base.DisposeManagedResources ();
 			if (Model != null) {
 				Model.Clear ();
 			}
@@ -109,6 +108,7 @@ namespace VAS.Core.ViewModel
 			EventTypesTimeline = null;
 			FullTimeline = null;
 			TeamsTimeline = null;
+			base.DisposeManagedResources ();
 		}
 
 		/// <summary>
@@ -117,7 +117,7 @@ namespace VAS.Core.ViewModel
 		/// <value>The edition command.</value>
 		public Command EditionCommand { get; set; }
 
-		public new RangeObservableCollection<TimelineEvent> Model {
+		public override RangeObservableCollection<TimelineEvent> Model {
 			get {
 				return model;
 			}

--- a/VAS.Core/ViewModel/VideoPlayerVM.cs
+++ b/VAS.Core/ViewModel/VideoPlayerVM.cs
@@ -596,7 +596,9 @@ namespace VAS.Core.ViewModel
 		{
 			PlaylistVM playlist = new PlaylistVM { Model = new Playlist () };
 
-			var plays = events.Select (vm => new PlaylistPlayElementVM { Model = new PlaylistPlayElement (vm.Model) });
+			var plays = events.Select (vm => new PlaylistPlayElementVM (vm) {
+				Model = new PlaylistPlayElement (vm.Model)
+			}).ToList ();
 
 			playlist.ViewModels.AddRange (plays);
 
@@ -685,7 +687,7 @@ namespace VAS.Core.ViewModel
 			DrawCommand = new Command (() => Player.DrawFrame ());
 			ConfigureCommand (DrawCommand, Icons.PlayerControlDraw, Sizes.PlayerCapturerIconSize, StyleConf.PlayerTooltipDraw);
 
-			DetachCommand = new LimitationCommand (VASFeature.VideoDetach.ToString(), () => { App.Current.EventsBroker.Publish (new DetachEvent ()); });
+			DetachCommand = new LimitationCommand (VASFeature.VideoDetach.ToString (), () => { App.Current.EventsBroker.Publish (new DetachEvent ()); });
 			ConfigureCommand (DetachCommand, Icons.PlayerControlDetach, Sizes.PlayerCapturerIconSize, StyleConf.PlayerTooltipDetach);
 
 			ViewPortsSwitchToggleCommand = new Command (() => {

--- a/VAS.Services/Controller/PlaylistController.cs
+++ b/VAS.Services/Controller/PlaylistController.cs
@@ -178,9 +178,9 @@ namespace VAS.Services.Controller
 			}
 
 			foreach (var item in e.PlaylistElements) {
-				if (item is TimelineEventVM) {
-					e.Playlist.ViewModels.Add (new PlaylistPlayElementVM () {
-						Model = new PlaylistPlayElement ((item as TimelineEventVM).Model),
+				if (item is TimelineEventVM timelineEventVM) {
+					e.Playlist.ViewModels.Add (new PlaylistPlayElementVM (timelineEventVM) {
+						Model = new PlaylistPlayElement (timelineEventVM.Model),
 					});
 				} else {
 					e.Playlist.ViewModels.Add ((PlaylistElementVM)item);

--- a/VAS.Services/VAS.Services.projitems
+++ b/VAS.Services/VAS.Services.projitems
@@ -50,6 +50,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\AboutVM.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DynamicButtonToolbarService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel\EditPlaylistElementVM.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ViewModelFactoryBaseService.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)ViewModel\" />

--- a/VAS.Services/ViewModelFactoryBaseService.cs
+++ b/VAS.Services/ViewModelFactoryBaseService.cs
@@ -1,0 +1,102 @@
+﻿//
+//  Copyright (C) 2018 Fluendo S.A.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+using System;
+using System.Collections.Generic;
+using VAS.Core.Common;
+using VAS.Core.Interfaces;
+using VAS.Core.Interfaces.MVVMC;
+using VAS.Core.Store;
+using VAS.Core.Store.Playlists;
+using VAS.Core.ViewModel;
+
+namespace VAS.Services
+{
+	/// <summary>
+	/// View model factory service, creates correctly typed ViewModel instances based on it's model.
+	/// This is useful to work with base classes and create child viewmodels without knowing the derived type
+	/// </summary>
+	public class ViewModelFactoryBaseService : IViewModelFactoryService
+	{
+		public ViewModelFactoryBaseService ()
+		{
+			TypeMappings = new Dictionary<Type, Type> ();
+			TypeMappings.Add (typeof (PlaylistPlayElement), typeof (PlaylistPlayElementVM));
+			TypeMappings.Add (typeof (PlaylistVideo), typeof (PlaylistVideoVM));
+			TypeMappings.Add (typeof (PlaylistImage), typeof (PlaylistImageVM));
+			TypeMappings.Add (typeof (PlaylistDrawing), typeof (PlaylistDrawingVM));
+			TypeMappings.Add (typeof (AnalysisEventButton), typeof (AnalysisEventButtonVM));
+			TypeMappings.Add (typeof (TagButton), typeof (TagButtonVM));
+			TypeMappings.Add (typeof (TimerButton), typeof (TimerButtonVM));
+		}
+
+		/// <summary>
+		/// Gets the TypeMappings Dictionary, where Key is the Model Type and Value is the ViewModel Type
+		/// </summary>
+		/// <value>The Type Mappings</value>
+		protected Dictionary<Type, Type> TypeMappings {
+			get;
+		}
+
+		/// <summary>
+		/// Adds a new TypeMapping
+		/// </summary>
+		/// <param name="modelType">Model type.</param>
+		/// <param name="viewModelType">View model type.</param>
+		public void AddTypeMapping (Type modelType, Type viewModelType)
+		{
+			TypeMappings.Add (modelType, viewModelType);
+		}
+
+		/// <summary>
+		/// Creates a ViewModel based on a Model
+		/// </summary>
+		/// <returns>The derived instance of the ViewModel</returns>
+		/// <param name="model">the model</param>
+		public TViewModel CreateViewModel<TViewModel, TModel> (TModel model)
+			where TViewModel : IViewModel<TModel>, new()
+		{
+			Type viewModelType;
+			Type modelType = model.GetType ();
+			TViewModel viewModel = default (TViewModel);
+
+			// If there's a typeMapping defined for the specific type
+			if (TypeMappings.TryGetValue (modelType, out viewModelType)) {
+				Log.Verbose ($"TypeMapping found {modelType} => {viewModelType}");
+				viewModel = (TViewModel)Activator.CreateInstance (viewModelType);
+			} else {
+				// If there isn't, get the first mapping that matches a parent class
+				foreach (var type in TypeMappings.Keys) {
+					if (type.IsAssignableFrom (modelType)) {
+						if (TypeMappings.TryGetValue (type, out viewModelType)) {
+							Log.Verbose ($"TypeMapping found {modelType} => {viewModelType}");
+							viewModel = (TViewModel)Activator.CreateInstance (viewModelType);
+							break;
+						}
+					}
+				}
+			}
+
+			if (viewModel == null) {
+				Log.Verbose ($"TypeMapping not found for {modelType}. Using the base ViewModel {typeof (TViewModel).Name}");
+				viewModel = new TViewModel ();
+			}
+			viewModel.Model = model;
+			return viewModel;
+		}
+	}
+}

--- a/VAS.Tests/Services/TestViewModelFactoryBaseService.cs
+++ b/VAS.Tests/Services/TestViewModelFactoryBaseService.cs
@@ -1,0 +1,155 @@
+﻿//
+//  Copyright (C) 2018 Fluendo S.A.
+//
+//  This program is free software; you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation; either version 2 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program; if not, write to the Free Software
+//  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+//
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using VAS.Core.Interfaces;
+using VAS.Core.Store;
+using VAS.Core.Store.Playlists;
+using VAS.Core.ViewModel;
+using VAS.Services;
+using VAS.Core.Common;
+
+namespace VAS.Tests.Services
+{
+	[TestFixture]
+	public class TestViewModelFactoryBaseService
+	{
+		VMFactoryServiceTest factoryService;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			factoryService = new VMFactoryServiceTest ();
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_TypeMappingsInitialized ()
+		{
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (PlaylistPlayElement)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (PlaylistPlayElement)], typeof (PlaylistPlayElementVM));
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (PlaylistVideo)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (PlaylistVideo)], typeof (PlaylistVideoVM));
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (PlaylistImage)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (PlaylistImage)], typeof (PlaylistImageVM));
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (PlaylistDrawing)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (PlaylistDrawing)], typeof (PlaylistDrawingVM));
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (AnalysisEventButton)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (AnalysisEventButton)], typeof (AnalysisEventButtonVM));
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (TagButton)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (TagButton)], typeof (TagButtonVM));
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (TimerButton)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (TimerButton)], typeof (TimerButtonVM));
+			Assert.AreEqual (factoryService.TypeMappings.Count, 7);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_AddTypeMappings ()
+		{
+			factoryService.AddTypeMapping (typeof (Period), typeof (PeriodVM));
+
+			Assert.IsTrue (factoryService.TypeMappings.ContainsKey (typeof (Period)));
+			Assert.AreEqual (factoryService.TypeMappings [typeof (Period)], typeof (PeriodVM));
+			Assert.AreEqual (factoryService.TypeMappings.Count, 8);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreateViewModel_NotInTypeMappings ()
+		{
+			var period = new Period ();
+			var vm = factoryService.CreateViewModel<PeriodVM, Period> (period);
+
+			Assert.IsTrue (vm is PeriodVM);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreatePlaylistElementVM ()
+		{
+			var model = new PlaylistPlayElement (new TimelineEvent ());
+			var vm = factoryService.CreateViewModel<PlaylistElementVM, IPlaylistElement> (model);
+
+			Assert.IsTrue (vm is PlaylistPlayElementVM);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreatePlaylistVideoVM ()
+		{
+			var model = new PlaylistVideo (new MediaFile ());
+			var vm = factoryService.CreateViewModel<PlaylistElementVM, IPlaylistElement> (model);
+
+			Assert.IsTrue (vm is PlaylistVideoVM);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreatePlaylistImageVM ()
+		{
+			var model = new PlaylistImage (new Image (2, 2), new Time (1));
+			var vm = factoryService.CreateViewModel<PlaylistElementVM, IPlaylistElement> (model);
+
+			Assert.IsTrue (vm is PlaylistImageVM);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreatePlaylistDrawingVM ()
+		{
+			var model = new PlaylistDrawing (new FrameDrawing ());
+			var vm = factoryService.CreateViewModel<PlaylistElementVM, IPlaylistElement> (model);
+
+			Assert.IsTrue (vm is PlaylistDrawingVM);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreateAnalysisEventButtonVM ()
+		{
+			var model = new AnalysisEventButton ();
+			var vm = factoryService.CreateViewModel<DashboardButtonVM, DashboardButton> (model);
+
+			Assert.IsTrue (vm is AnalysisEventButtonVM);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreateTagButtonVM ()
+		{
+			var model = new TagButton ();
+			var vm = factoryService.CreateViewModel<DashboardButtonVM, DashboardButton> (model);
+
+			Assert.IsTrue (vm is TagButtonVM);
+		}
+
+		[Test]
+		public void ViewModelFactoryBaseService_CreateTimerButtonVM ()
+		{
+			var model = new TimerButton ();
+			var vm = factoryService.CreateViewModel<DashboardButtonVM, DashboardButton> (model);
+
+			Assert.IsTrue (vm is TimerButtonVM);
+		}
+	}
+
+	/// <summary>
+	/// VM Factory service test. Just to get the typeMappings in test
+	/// </summary>
+	class VMFactoryServiceTest : ViewModelFactoryBaseService
+	{
+		public new Dictionary<Type, Type> TypeMappings {
+			get {
+				return base.TypeMappings;
+			}
+		}
+	}
+}

--- a/VAS.Tests/Setup.cs
+++ b/VAS.Tests/Setup.cs
@@ -51,6 +51,7 @@ namespace VAS.Tests
 			App.Current.DependencyRegistry.Register<IStopwatch, Stopwatch> (1);
 			App.Current.DependencyRegistry.Register<ITimer, Timer> (1);
 			App.Current.DependencyRegistry.Register<ISeeker, InstantSeeker> (1);
+			App.Current.DependencyRegistry.Register<IViewModelFactoryService, ViewModelFactoryBaseService> (1);
 			App.Current.Dialogs = new Mock<IDialogs> ().Object;
 			var navigation = new Mock<INavigation> ();
 			navigation.Setup (x => x.Push (It.IsAny<IPanel> ())).Returns (AsyncHelpers.Return (true));

--- a/VAS.Tests/VAS.Tests.csproj
+++ b/VAS.Tests/VAS.Tests.csproj
@@ -167,6 +167,7 @@
     <Compile Include="UI\TestExtensionMethods.cs" />
     <Compile Include="Drawing\Widgets\TestFillCanvas.cs" />
     <Compile Include="Core\ViewModel\TestPercentCircularChartVM.cs" />
+    <Compile Include="Services\TestViewModelFactoryBaseService.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
- This fixes a bug where the eye was not visible due to creation of other TimelineEventVM Instance

#### Things to review:
- [x] Unit tests
- [x] No hardcoded resources (strings, sizes, colors...)
- [x] Sorted usings
- [ ] Add summaries where needed 

If needed, you can add new checkboxes to https://github.com/fluendo/VAS/blob/master/.github/PULL_REQUEST_TEMPLATE.md
