### PR TITLE
Extract the parseModifier to a public method

### DIFF
--- a/VAS.Core/Interfaces/IKeyboard.cs
+++ b/VAS.Core/Interfaces/IKeyboard.cs
@@ -56,5 +56,12 @@ namespace VAS.Core.Interfaces
 		/// <returns>A hotkey.</returns>
 		/// <param name="evt">The event to parse.</param>
 		HotKey ParseEvent (object evt);
+
+		/// <summary>
+		/// Parses a native key or mouse pressed event from the UI toolkit and returns the modifiers used.
+		/// </summary>
+		/// <returns>A hotkey.</returns>
+		/// <param name="evt">The event to parse.</param>
+		int ParseModifier (object evt);
 	}
 }

--- a/VAS.UI.Gtk2/UI/Common/TreeViewBase.cs
+++ b/VAS.UI.Gtk2/UI/Common/TreeViewBase.cs
@@ -336,7 +336,8 @@ namespace VAS.UI.Common
 					dragStarted = false;
 					dragStart = new Point (evnt.X, evnt.Y);
 				}
-				if (evnt.State == ModifierType.None) {
+				int modifier = App.Current.Keyboard.ParseModifier (evnt);
+				if (modifier == 0) {
 					GetPathAtPos ((int)evnt.X, (int)evnt.Y, out pathClicked);
 				}
 			}


### PR DESCRIPTION
It can be used with EventKeys and EventButtons, although they don't have any common interface with the 'State' property

#### Things to review:
- [ ] Unit tests
- [ ] No hardcoded resources (strings, sizes, colors...)
- [ ] Sorted usings
- [ ] Add summaries where needed 

If needed, you can add new checkboxes to https://github.com/fluendo/VAS/blob/master/.github/PULL_REQUEST_TEMPLATE.md
