### PR TITLE
Fix Contract Resolvers to use always same instance for cache

### DIFF
--- a/VAS.Core/Store/TimelineEvent.cs
+++ b/VAS.Core/Store/TimelineEvent.cs
@@ -192,6 +192,7 @@ namespace VAS.Core.Store
 		}
 
 		[PropertyChanged.DoNotNotify]
+		[CloneIgnore]
 		[JsonIgnore]
 		public Project Project {
 			get;
@@ -203,6 +204,7 @@ namespace VAS.Core.Store
 		/// </summary>
 		[PropertyPreload]
 		[PropertyIndex (1)]
+		[CloneIgnore]
 		public EventType EventType {
 			get;
 			set;
@@ -221,6 +223,7 @@ namespace VAS.Core.Store
 		/// </summary>
 		[PropertyIndex (0)]
 		[JsonProperty]
+		[CloneIgnore]
 		public RangeObservableCollection<Player> Players {
 			get;
 			private set;
@@ -481,12 +484,13 @@ namespace VAS.Core.Store
 		/// <summary>
 		/// Clone this instance, creating a deep copy of the object with a new ID
 		/// </summary>
-		public TimelineEvent Clone ()
+		public virtual TimelineEvent Clone ()
 		{
 			var newplay = Cloner.Clone (this);
 			newplay.ID = Guid.NewGuid ();
 			newplay.EventType = EventType;
-			newplay.Players = Players;
+			newplay.Players = new RangeObservableCollection<Player> (Players);
+			newplay.Project = Project;
 			return newplay;
 		}
 

--- a/VAS.Services/Controller/PlaylistController.cs
+++ b/VAS.Services/Controller/PlaylistController.cs
@@ -179,8 +179,8 @@ namespace VAS.Services.Controller
 
 			foreach (var item in e.PlaylistElements) {
 				if (item is TimelineEventVM timelineEventVM) {
-					e.Playlist.ViewModels.Add (new PlaylistPlayElementVM (timelineEventVM) {
-						Model = new PlaylistPlayElement (timelineEventVM.Model),
+					e.Playlist.ViewModels.Add (new PlaylistPlayElementVM () {
+						Model = new PlaylistPlayElement (timelineEventVM.Model.Clone ()),
 					});
 				} else {
 					e.Playlist.ViewModels.Add ((PlaylistElementVM)item);

--- a/VAS.Tests/Services/TestPlaylistController.cs
+++ b/VAS.Tests/Services/TestPlaylistController.cs
@@ -209,6 +209,38 @@ namespace VAS.Tests.Services
 		}
 
 		[Test]
+		public async Task AddTimelineEventsToPlaylist_ClonesTimelineEvents ()
+		{
+			SetupWithStorage ();
+			var newPlaylist = new Playlist ();
+			newPlaylist.Elements.Add (new PlaylistPlayElement (new TimelineEvent ()));
+			playlistCollectionVM.Model.Add (newPlaylist);
+
+
+			var timelineEvent = new TimelineEvent {
+				Name = "test",
+				ID = Guid.NewGuid ()
+			};
+
+			await App.Current.EventsBroker.Publish (
+				new AddPlaylistElementEvent {
+					PlaylistElements = new List<IPlayable> {
+						new TimelineEventVM { Model = timelineEvent }},
+					Playlist = playlistCollectionVM.ViewModels [0]
+				}
+			);
+
+			var timelineEventAdded = ((PlaylistPlayElement)playlistCollectionVM.Model [0].Elements [1]).Play;
+
+			Assert.AreNotEqual (timelineEvent.ID, timelineEventAdded.ID);
+			Assert.AreEqual (timelineEvent.Name, timelineEventAdded.Name);
+
+			timelineEventAdded.Name = "test2";
+
+			Assert.AreEqual ("test", timelineEvent.Name);
+		}
+
+		[Test]
 		public async Task TestAddEventsToExistingPlaylistWithProject ()
 		{
 			SetupWithProject ();


### PR DESCRIPTION
- Divide IsChangedContractResolver into two resolvers:
    - IsChangedContractResolver and ClonerContractResolver
- Improves performance speed for Cloning objects by reusing the
same contract resolver instance that caches types
- Also fix how new playlist elements are created based on TimelineEvent,
Basically we need to clone the timeline event to fix corrupted database

#### Things to review:
- [ ] Unit tests
- [ ] No hardcoded resources (strings, sizes, colors...)
- [ ] Sorted usings
- [ ] Add summaries where needed 

If needed, you can add new checkboxes to https://github.com/fluendo/VAS/blob/master/.github/PULL_REQUEST_TEMPLATE.md
