### PR TITLE
Change dll.config after the changes in packaging

### DIFF
--- a/VAS.UI.Helpers.Gtk2/VAS.UI.Helpers.Gtk2.dll.config
+++ b/VAS.UI.Helpers.Gtk2/VAS.UI.Helpers.Gtk2.dll.config
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-	<dllmap dll="libvas.dll" target="libvas.0.dylib" />
-	<dllmap os="linux" dll="libvas.dll" target="libvas.so.0" />
-	<dllmap os="windows" dll="libvas.dll" target="libvas-0.dll" />
+	<dllmap dll="libvas.dll" target="libvas.dylib" />
+	<dllmap os="linux" dll="libvas.dll" target="libvas.so" />
+	<dllmap os="windows" dll="libvas.dll" target="libvas.dll" />
 	<dllmap dll="libgtk-2.0.dll" target="libgtk-quartz-2.0.0.dylib" />
 	<dllmap os="linux" dll="libgtk-2.0.dll" target="libgtk-x11-2.0.so.0" />
 	<dllmap os="windows" dll="libgtk-2.0.dll" target="libgtk-win32-2.0-0.dll" />


### PR DESCRIPTION
Before we were packaging too many things, including libvas.0.dylib and libvas.dylib (both exactly the same).
Now we are only packaging libvas.dylib.

And for some reason we had two dll.config pointing to the two different libs, so this one has to change
