### PR TITLE
Fixes in video conversion tool

### DIFF
--- a/VAS.Services/RenderingJobsController.cs
+++ b/VAS.Services/RenderingJobsController.cs
@@ -130,7 +130,7 @@ namespace VAS.Services
 			IEnumerable<Job> jobs = evt.Object;
 			evt.ReturnValue = false;
 
-			foreach (Job job in ViewModel.Model.Intersect (jobs)) {
+			foreach (Job job in ViewModel.Model.Intersect (jobs).ToList ()) {
 				// Remove jobs from the list and add them back to the queue
 				ViewModel.Model.Remove (job);
 				job.State = JobState.Pending;
@@ -196,9 +196,13 @@ namespace VAS.Services
 			videoEditor.Error += OnError;
 
 			foreach (MediaFile file in job.InputFiles) {
-				PlaylistVideo video = new PlaylistVideo (file);
-				Log.Debug ("Convert video " + video.File.FilePath);
-				videoEditor.AddSegment (video.File.FilePath, 0, file.Duration.MSeconds, 1, "", video.File.HasAudio, new Area ());
+				Log.Debug ("Convert video " + file.FilePath);
+				long duration = -1;
+				// VideoEditor has problems with files without audio if we do not specify the duration
+				if (!file.HasAudio) {
+					duration = file.Duration.MSeconds;
+				}
+				videoEditor.AddSegment (file.FilePath, 0, duration, 1, "", file.HasAudio, new Area ());
 			}
 
 			videoEditor.Start ();

--- a/libvas/gst-remuxer.c
+++ b/libvas/gst-remuxer.c
@@ -374,8 +374,8 @@ gst_remuxer_have_type_cb (GstElement * typefind, guint prob,
   GST_INFO_OBJECT (remuxer, "Found mime type: %s", mime);
 
   if (g_strrstr (mime, "video/mpegts")) {
-    GST_INFO_OBJECT (remuxer, "Using tsdemux as demuxer");
-    demuxer = gst_element_factory_make ("tsdemux", NULL);
+    GST_INFO_OBJECT (remuxer, "Using flutsdemux as demuxer");
+    demuxer = gst_element_factory_make ("flutsdemux", NULL);
   } else if (g_strrstr (mime, "video/x-ms-asf")) {
     GST_INFO_OBJECT (remuxer, "Using asfdemux as demuxer");
     demuxer = gst_element_factory_make ("asfdemux", NULL);

--- a/libvas/gst-video-editor.c
+++ b/libvas/gst-video-editor.c
@@ -526,8 +526,14 @@ gst_video_editor_add_segment (GstVideoEditor * gve, gchar * file,
       GST_TIME_FORMAT "} ", GST_TIME_ARGS (gve->priv->duration),
       GST_TIME_ARGS (duration));
 
-  if (duration != -1)
-    gve->priv->duration += duration;
+  if (duration != -1) {
+    if (gve->priv->duration >= 0)
+      gve->priv->duration += duration;
+  } else {
+    /* if some of the segments has unknown duration
+       we force the fallback to source progress reporting */
+    gve->priv->duration = -1;
+  }
 }
 
 void


### PR DESCRIPTION
1) mpegts files with audio was failing to convert, because of a bug in oneplay-engine,
that reports a bad file duration, and it should wait more to get the duration
2) for video files without audio, we specify a duration in order to convert them
3) the only combo that needs to be fixed are mpegts video files without audio,
this needs to be solved in the oneplay-engine.

#### Things to review:
- [ ] Unit tests
- [ ] No hardcoded resources (strings, sizes, colors...)
- [ ] Sorted usings
- [ ] Add summaries where needed 

If needed, you can add new checkboxes to https://github.com/fluendo/VAS/blob/master/.github/PULL_REQUEST_TEMPLATE.md
